### PR TITLE
Made build numbers work properly

### DIFF
--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -1,9 +1,13 @@
 .PHONY: itest_% clean shell
 PROJECT = terraform-provider-nsone
 
-BUILD_NUMBER ?= 0
-REAL_BUILD_NUMBER ?= $(upstream_build_number)
-REAL_BUILD_NUMBER ?= $(BUILD_NUMBER)
+
+BUILD_NUMBER?=0
+ifdef upstream_build_number
+	REAL_BUILD_NUMBER=$(upstream_build_number)
+else
+	REAL_BUILD_NUMBER?=$(BUILD_NUMBER)
+endif
 VERSION = 0.2
 ITERATION = yelp$(REAL_BUILD_NUMBER)
 ARCH := $(shell facter architecture)


### PR DESCRIPTION
After doing the following test:

$ cat Makefile
BUILD_NUMBER?=0
ifdef upstream_build_number
        REAL_BUILD_NUMBER=$(upstream_build_number)
else
        REAL_BUILD_NUMBER?=$(BUILD_NUMBER)
endif
ITERATION=yelp$(REAL_BUILD_NUMBER)

default:
        echo $(ITERATION)
$ make
echo yelp0
yelp0
$ BUILD_NUMBER=1 make
echo yelp1
yelp1
$ BUILD_NUMBER=1 upstream_build_number=2 make
echo yelp2
yelp2
$
