### PR TITLE
Fix package building on lucid

### DIFF
--- a/yelppack/Dockerfile
+++ b/yelppack/Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     go \
     git \
     build-essential \
-    ruby1.8 rubygems \
-    libopenssl-ruby \
-    ruby-dev \
+    ruby1.9.1 rubygems1.9.1 \
+    libopenssl-ruby1.9.1 \
+    ruby1.9.1-dev \
     --no-install-recommends
 
 ENV GOPATH /go
-
-RUN gem install fpm --version 1.3.3
-RUN ln -s /var/lib/gems/1.8/bin/fpm /usr/local/bin/fpm
+ENV RUBYOPT="-KU -E utf-8:utf-8"
+RUN gem install fpm
+RUN ln -s /var/lib/gems/1.9.1/bin/fpm /usr/local/bin/fpm
 
 #WORKDIR /go/src/github.com/Yelp/terraform-provider-gitfile

--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -8,9 +8,9 @@ ifdef upstream_build_number
 else
 	REAL_BUILD_NUMBER?=$(BUILD_NUMBER)
 endif
-VERSION = 0.2
+VERSION = 0.3
 ITERATION = yelp$(REAL_BUILD_NUMBER)
-ARCH := $(shell facter architecture)
+ARCH := $(shell dpkg --print-architecture)
 
 PACKAGE_NAME := $(PROJECT)_$(VERSION)-$(ITERATION)_$(ARCH).deb
 PACKAGE_FILE := dist/$(PACKAGE_NAME)


### PR DESCRIPTION
This fixes building package on lucid by working around the cabin bug with ruby1.8.7
