### PR TITLE
Acceptance test for resource nsone_zone

### DIFF
--- a/nsone/resource_zone_test.go
+++ b/nsone/resource_zone_test.go
@@ -16,7 +16,7 @@ func TestAccZone_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccZone_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckZoneState("zone", "example.com"),
+					testAccCheckZoneState("zone", "terraform.io"),
 				),
 			},
 		},
@@ -46,6 +46,6 @@ func testAccCheckZoneState(key, value string) resource.TestCheckFunc {
 
 const testAccZone_basic = `
 resource "nsone_zone" "foobar" {
-	zone = "example.com"
-	hostmaster = "example.com"
+	zone = "terraform.io"
+	hostmaster = "hostmaster@nsone.net"
 }`

--- a/nsone/resource_zone_test.go
+++ b/nsone/resource_zone_test.go
@@ -4,19 +4,51 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/bobtfish/go-nsone-api"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccZone_basic(t *testing.T) {
+	var zone nsone.Zone
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccZone_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneState("zone", "terraform.io"),
+					testAccCheckZoneExists("nsone_zone.foobar", &zone),
+					testAccCheckZoneAttributes(&zone),
+				),
+			},
+		},
+	})
+}
+
+func TestAccZone_updated(t *testing.T) {
+	var zone nsone.Zone
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccZone_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckZoneState("zone", "terraform.io"),
+					testAccCheckZoneExists("nsone_zone.foobar", &zone),
+					testAccCheckZoneAttributes(&zone),
+				),
+			},
+			resource.TestStep{
+				Config: testAccZone_updated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckZoneState("zone", "terraform.io"),
+					testAccCheckZoneExists("nsone_zone.foobar", &zone),
+					testAccCheckZoneAttributesUpdated(&zone),
 				),
 			},
 		},
@@ -44,8 +76,96 @@ func testAccCheckZoneState(key, value string) resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckZoneExists(n string, zone *nsone.Zone) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("NoID is set")
+		}
+
+		client := testAccProvider.Meta().(*nsone.APIClient)
+
+		foundZone, err := client.GetZone(rs.Primary.Attributes["zone"])
+
+		p := rs.Primary
+
+		if err != nil {
+			return err
+		}
+
+		if foundZone.Id != p.Attributes["id"] {
+			return fmt.Errorf("Zone not found")
+		}
+
+		*zone = *foundZone
+
+		return nil
+	}
+}
+
+func testAccCheckZoneDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*nsone.APIClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "nsone_zone" {
+			continue
+		}
+
+		_, err := client.GetZone(rs.Primary.Attributes["zone"])
+
+		if err == nil {
+			return fmt.Errorf("Record still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckZoneAttributes(zone *nsone.Zone) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if zone.Ttl != 3600 {
+			return fmt.Errorf("Bad value : %d", zone.Ttl)
+		}
+
+		if zone.Nx_ttl != 3600 {
+			return fmt.Errorf("Bad value : %d", zone.Nx_ttl)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckZoneAttributesUpdated(zone *nsone.Zone) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if zone.Ttl != 3601 {
+			return fmt.Errorf("Bad value : %d", zone.Ttl)
+		}
+
+		if zone.Nx_ttl != 3601 {
+			return fmt.Errorf("Bad value : %d", zone.Nx_ttl)
+		}
+
+		return nil
+	}
+}
+
 const testAccZone_basic = `
 resource "nsone_zone" "foobar" {
 	zone = "terraform.io"
 	hostmaster = "hostmaster@nsone.net"
+	ttl = "3600"
+	nx_ttl = "3600"
+}`
+
+const testAccZone_updated = `
+resource "nsone_zone" "foobar" {
+	zone = "terraform.io"
+	hostmaster = "hostmaster@nsone.net"
+	ttl = "3601"
+	nx_ttl = "3601"
 }`


### PR DESCRIPTION
Acceptance test currently fails because of "zone already exists error" and hostmaster being rejected. This fixes the acceptance tests and also adds real acceptance tests, which uses the nsone API to validate the zone settings
