### PR TITLE
use edns_client_subnet should be off by default

### DIFF
--- a/nsone/resource_record.go
+++ b/nsone/resource_record.go
@@ -58,7 +58,7 @@ func recordResource() *schema.Resource {
 			"use_client_subnet": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 			"answers": &schema.Schema{
 				Type:     schema.TypeSet,


### PR DESCRIPTION
Enabling the edns-client-subnet gets better resolution on intelligent records, but otherwise just increases query traffic.
