### PR TITLE
Make the build work for anyone on a typical Unix/Docker system

### DIFF
--- a/yelppack/Dockerfile
+++ b/yelppack/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-dev.yelpcorp.com/trusty_yelp
+FROM ubuntu:trusty
 
 MAINTAINER Tomas Doran <bobtfish@bobtfish.net>
 
@@ -9,6 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     ruby1.9.1 rubygems1.9.1 \
     libopenssl-ruby1.9.1 \
     ruby1.9.1-dev \
+    rpm \
     --no-install-recommends
 RUN wget https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz && tar xzf go1.7.linux-amd64.tar.gz && mv go /usr/local
 ENV PATH /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin:/usr/local/go/bin:/go/bin

--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -11,7 +11,7 @@ endif
 VERSION = 0.5
 TF_VERSION = 0.8
 ITERATION = yelp$(REAL_BUILD_NUMBER)
-ARCH := $(shell dpkg --print-architecture)
+ARCH := $(shell uname -m)
 
 PACKAGE_NAME := $(PROJECT)-$(TF_VERSION)_$(VERSION)-$(ITERATION)_$(ARCH).deb
 PACKAGE_FILE := dist/$(PACKAGE_NAME)
@@ -24,7 +24,7 @@ itest_%: $(PACKAGE_FILE)
 	docker run --rm -v $(CURDIR)/../dist:/dist:ro -v $(CURDIR)/itest.sh:/itest.sh:ro docker-dev.yelpcorp.com/$*_yelp:latest bash /itest.sh /$(PACKAGE_FILE) $(TF_VERSION)
 
 $(PACKAGE_FILE): .docker_container_id
-	docker cp $$(cat .docker_container_id):/$(PACKAGE_FILE) ../dist/
+	docker cp $$(cat .docker_container_id):/dist ..
 
 .docker_container_id: .docker_image_id
 	docker run --rm=false \
@@ -32,7 +32,7 @@ $(PACKAGE_FILE): .docker_container_id
 		-v $(CURDIR)/build.sh:/build.sh:ro \
 		--cidfile=$(CURDIR)/.docker_container_id \
 		$$(cat .docker_image_id) \
-		bash /build.sh $(PROJECT) $(VERSION) $(ITERATION) $(TF_VERSION) || \
+		bash -xve /build.sh $(PROJECT) $(VERSION) $(ITERATION) $(TF_VERSION) || \
 	(retval=$$?; $(CLEAN_CONTAINER); exit $$retval; )
 
 .docker_image_id: Dockerfile

--- a/yelppack/build.sh
+++ b/yelppack/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -exv
 
 project=$1
 version=$2
@@ -9,6 +9,12 @@ go get github.com/bobtfish/${project}
 mkdir /dist && cd /dist
 mkdir /tmp/usrbin
 fpm -s dir -t deb --deb-no-default-config-files --name ${project}-${tf_version} \
+    --iteration ${iteration} --version ${version} \
+    /go/bin/${project}=/nail/opt/terraform-${tf_version}/bin/
+fpm -s dir -t rpm --name ${project}-${tf_version} \
+    --iteration ${iteration} --version ${version} \
+    /go/bin/${project}=/nail/opt/terraform-${tf_version}/bin/
+fpm -s dir -t tar --name ${project}-${tf_version} \
     --iteration ${iteration} --version ${version} \
     /go/bin/${project}=/nail/opt/terraform-${tf_version}/bin/
 


### PR DESCRIPTION
This makes changes to allow this to build on standard Unix based system running Docker.

* Builds a deb, rpm, and tar file.
* Uses a standard upstream docker image

