### PR TITLE
Add generic docker-based building for multiple platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ terraform.tfstate.backup
 crash.log
 yelppack/.docker_container_id
 yelppack/.docker_image_id
+build/.docker_container_id
+build/.docker_image_id
 dist/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:trusty
+
+MAINTAINER Tomas Doran <bobtfish@bobtfish.net>
+
+ENV TF_VERSION=0.8.2
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+    wget \
+    git \
+    build-essential \
+    ruby1.9.1 rubygems1.9.1 \
+    libopenssl-ruby1.9.1 \
+    ruby1.9.1-dev \
+    rpm \
+    --no-install-recommends
+RUN wget https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz && tar xzf go1.7.linux-amd64.tar.gz && mv go /usr/local
+ENV PATH /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin:/usr/local/go/bin:/go/bin
+ENV GOPATH /go
+RUN mkdir /go
+ENV RUBYOPT="-KU -E utf-8:utf-8"
+RUN gem install fpm
+RUN git clone https://github.com/hashicorp/terraform.git /go/src/github.com/hashicorp/terraform && \
+    cd /go/src/github.com/hashicorp/terraform && \
+    git checkout v${TF_VERSION}

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,41 @@
+.PHONY: itest_% clean shell
+PROJECT = terraform-provider-nsone
+
+BUILD_NUMBER?=0
+ifdef upstream_build_number
+	REAL_BUILD_NUMBER=$(upstream_build_number)
+else
+	REAL_BUILD_NUMBER?=$(BUILD_NUMBER)
+endif
+VERSION = 0.5
+TF_VERSION = 0.8.2
+ITERATION = default$(REAL_BUILD_NUMBER)
+
+DOCKER_TAG = $(PROJECT)_$(shell date +%s)
+
+CLEAN_CONTAINER := [ -e .docker_container_id ] && docker rm --force $$(cat .docker_container_id) || true; rm -f .docker_container_id
+
+output: .docker_container_id
+	docker cp $$(cat .docker_container_id):/dist ..
+
+.docker_container_id: .docker_image_id
+	docker run --rm=false \
+		-v $(CURDIR)/..:/go/src/github.com/bobtfish/terraform-provider-nsone:ro \
+		-v $(CURDIR)/build.sh:/build.sh:ro \
+		--cidfile=$(CURDIR)/.docker_container_id \
+		$$(cat .docker_image_id) \
+		bash -xve /build.sh $(PROJECT) $(VERSION) $(ITERATION) $(TF_VERSION) || \
+	(retval=$$?; $(CLEAN_CONTAINER); exit $$retval; )
+
+.docker_image_id: Dockerfile
+	docker build -t $(DOCKER_TAG) .
+	docker inspect -f '{{ .Id }}' $(DOCKER_TAG) > .docker_image_id
+
+clean:
+	$(CLEAN_CONTAINER)
+	rm -f .docker_image_id
+	rm -rf ../dist
+
+shell: .docker_image_id
+	docker run --rm -t -i $$(cat .docker_image_id) /bin/bash
+

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -exv
+
+project=$1
+version=$2
+iteration=$3
+tf_version=$4
+
+mkdir /dist
+go get -v github.com/bobtfish/${project}
+env GOOS=linux GOARCH=amd64 go build -v -o /dist/${project}-linux64 github.com/bobtfish/${project}
+env GOOS=darwin GOARCH=amd64 go build -v -o /dist/${project}-darwin64 github.com/bobtfish/${project}
+env GOOS=windows GOARCH=amd64 go build -v -o /dist/${project}-windows64 github.com/bobtfish/${project}
+


### PR DESCRIPTION
This forks the yelppack directory into a build directory and makes it a much more generic Docker-based build process that will output binaries for linux64, darwin64, and windows64.

This will run well on Linux, OS X, and very likely Windows.