### PR TITLE
Build for Terraform 0.12

### DIFF
--- a/yelppack/Dockerfile
+++ b/yelppack/Dockerfile
@@ -9,4 +9,4 @@ ENV RUBYOPT="-KU -E utf-8:utf-8"
 RUN mkdir -p /go && \
     git clone https://github.com/hashicorp/terraform.git /go/src/github.com/hashicorp/terraform && \
     cd /go/src/github.com/hashicorp/terraform && \
-    git checkout v0.11.7
+    git checkout v0.12.1

--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -9,7 +9,7 @@ else
 	REAL_BUILD_NUMBER?=$(BUILD_NUMBER)
 endif
 VERSION = 0.9.1
-TF_VERSION = 0.11
+TF_VERSION = 0.12
 ITERATION = yelp$(REAL_BUILD_NUMBER)
 ARCH := $(shell dpkg --print-architecture)
 


### PR DESCRIPTION
Checks out the Terraform 0.12.1 source and builds against it. make itest_xenial correctly builds a .deb artefact.